### PR TITLE
fix m11 cert

### DIFF
--- a/k8s/deployments/navigator/data-m11/ingress.yaml
+++ b/k8s/deployments/navigator/data-m11/ingress.yaml
@@ -21,7 +21,7 @@ spec:
           servicePort: 3333
   tls:
     - hosts:
-      - data-m10.internationalbrainlab.org
+      - data-m11.internationalbrainlab.org
       secretName: ibl-node-server-tls
 ...
 ---
@@ -44,6 +44,6 @@ spec:
           servicePort: 9000
   tls:
     - hosts:
-      - data-m10.internationalbrainlab.org
+      - data-m11.internationalbrainlab.org
       secretName: ibl-frontend-tls
 ...


### PR DESCRIPTION
It appears I missed two values when I set the names for tls in m11. These files have been successfully applied, and the certs are now fixed.